### PR TITLE
Send header origin as CORS access-control-allow-origin when defined a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.8.6 (January 27, 2021)
+* Send header origin as CORS access-control-allow-origin when defined as * in routes config
+
 ## 2.8.5 (January 26, 2021)
 * Removed EmbedModel in favour of enable/disable Models
 

--- a/lib/routesHandler/lib/initializeRoutes.js
+++ b/lib/routesHandler/lib/initializeRoutes.js
@@ -698,11 +698,15 @@ function thisModule() {
 
                             //Set cors header fields
                             for (var corsHeader in corsHeaders) {
-                              let headerValue = _.get(corsHeaders,corsHeader)
-                              if (_.isString(headerValue) || _.isNumber(headerValue) || _.isBoolean(headerValue)) {
-                                res.setHeader(corsHeader, headerValue);
-                              }
-                            }
+          					    let headerValue = _.get(corsHeaders, corsHeader)
+              				    if (_.isString(headerValue) || _.isNumber(headerValue) || _.isBoolean(headerValue)) {
+                 				   if (corsHeader.toLocaleLowerCase() === 'access-control-allow-origin' && headerValue === '*' && req.headers && req.headers.origin) {
+                   				       res.setHeader(corsHeader, req.headers.origin)
+               					   } else {
+               					       res.setHeader(corsHeader, headerValue)
+              					   }
+                				}
+           				   }
 
                             res.setHeader("Access-Control-Allow-Methods", requestMethod.toUpperCase() + ", OPTIONS");
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "middleware",
     "framework"
   ],
-  "version": "2.8.5",
+  "version": "2.8.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/7factory/mia-js-core.git"


### PR DESCRIPTION
Send header origin as CORS access-control-allow-origin when defined as * in routes config